### PR TITLE
issue #24

### DIFF
--- a/src/com/moxun/s2v/utils/CommonUtil.java
+++ b/src/com/moxun/s2v/utils/CommonUtil.java
@@ -65,7 +65,7 @@ public class CommonUtil {
     public static String getValidName(String s) {
         char[] chars = s.toLowerCase().replaceAll("\\s*", "").toCharArray();
         for (int i = 0; i < chars.length; i++) {
-            if (!Character.isLetter(chars[i])) {
+            if (!Character.isLetter(chars[i]) && !Character.isDigit(chars[i])) {
                 chars[i] = '_';
             }
         }


### PR DESCRIPTION
解决SVG文件名含有数字时，会被替换为下划线的问题，保持原来的数字